### PR TITLE
Vault - Read from key specific path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     docker:
       - image: circleci/golang:1.9.2-stretch
 
-    working_directory: /go/src/github.com/percolate/shisa
+    working_directory: /go/src/github.com/shisa-platform/core
 
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,10 @@ gen:
 test: ${COVERAGE_DIR} ${SHISA_TEST_PKGS}
 
 examples:
-	go build -o $(TOP_DIR)/$(BUILD_DIR)/rest github.com/percolate/shisa/examples/rest
-	go build -o $(TOP_DIR)/$(BUILD_DIR)/rpc github.com/percolate/shisa/examples/rpc
-	go build -o $(TOP_DIR)/$(BUILD_DIR)/idp github.com/percolate/shisa/examples/idp
-	go build -o $(TOP_DIR)/$(BUILD_DIR)/gw github.com/percolate/shisa/examples/gw
+	go build -o $(TOP_DIR)/$(BUILD_DIR)/rest github.com/shisa-platform/core/examples/rest
+	go build -o $(TOP_DIR)/$(BUILD_DIR)/rpc github.com/shisa-platform/core/examples/rpc
+	go build -o $(TOP_DIR)/$(BUILD_DIR)/idp github.com/shisa-platform/core/examples/idp
+	go build -o $(TOP_DIR)/$(BUILD_DIR)/gw github.com/shisa-platform/core/examples/gw
 
 docker:
 	docker build --tag shisa/examples/gw -f examples/gw/Dockerfile .
@@ -55,6 +55,9 @@ docker:
 	docker build --tag shisa/examples/rpc -f examples/rpc/Dockerfile .
 
 coverage/%:
-	go test -v -coverprofile=$(TOP_DIR)/$(COVERAGE_DIR)/$(@F)_coverage.out -covermode=atomic github.com/percolate/shisa/$(@F)
+	go test -v -coverprofile=$(TOP_DIR)/$(COVERAGE_DIR)/$(@F)_coverage.out -covermode=atomic github.com/shisa-platform/core/$(@F)
+
+t:
+	echo $(SHISA_PKGS)
 
 .PHONY: clean doc vet fmt test examples docker

--- a/authn/authenticator.go
+++ b/authn/authenticator.go
@@ -3,9 +3,9 @@ package authn
 import (
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/models"
 )
 
 const (

--- a/authn/authenticator_charlatan.go
+++ b/authn/authenticator_charlatan.go
@@ -4,9 +4,9 @@ package authn
 
 import "reflect"
 import "github.com/ansel1/merry"
-import "github.com/percolate/shisa/context"
-import "github.com/percolate/shisa/httpx"
-import "github.com/percolate/shisa/models"
+import "github.com/shisa-platform/core/context"
+import "github.com/shisa-platform/core/httpx"
+import "github.com/shisa-platform/core/models"
 
 // AuthenticatorAuthenticateInvocation represents a single call of FakeAuthenticator.Authenticate
 type AuthenticatorAuthenticateInvocation struct {

--- a/authn/basic.go
+++ b/authn/basic.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/models"
 )
 
 // BasicAuthTokenExtractor returns the decoded credentials from

--- a/authn/basic_test.go
+++ b/authn/basic_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/ansel1/merry"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/models"
 )
 
 var (

--- a/authn/bearer.go
+++ b/authn/bearer.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/models"
 )
 
 type bearerAuthenticator struct {

--- a/authn/bearer_test.go
+++ b/authn/bearer_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/ansel1/merry"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/models"
 )
 
 func mustMakeBearerAuthenticator(idp IdentityProvider) Authenticator {

--- a/authn/generic.go
+++ b/authn/generic.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/models"
 )
 
 type genericAuthenticator struct {

--- a/authn/generic_test.go
+++ b/authn/generic_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/ansel1/merry"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/models"
 )
 
 func mustMakeGenericAuthenticator(extractor httpx.StringExtractor, idp IdentityProvider) Authenticator {

--- a/authn/idp.go
+++ b/authn/idp.go
@@ -3,8 +3,8 @@ package authn
 import (
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/models"
 )
 
 //go:generate charlatan -output=./idp_charlatan.go IdentityProvider

--- a/authn/idp_charlatan.go
+++ b/authn/idp_charlatan.go
@@ -3,9 +3,9 @@
 package authn
 
 import "github.com/ansel1/merry"
-import "github.com/percolate/shisa/context"
+import "github.com/shisa-platform/core/context"
 
-import "github.com/percolate/shisa/models"
+import "github.com/shisa-platform/core/models"
 import "reflect"
 
 // IdentityProviderAuthenticateInvocation represents a single call of FakeIdentityProvider.Authenticate

--- a/authn/token.go
+++ b/authn/token.go
@@ -4,8 +4,8 @@ import (
 	"github.com/ansel1/merry"
 	"strings"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
 )
 
 // AuthenticationHeaderTokenExtractor returns the token from the

--- a/authn/token_test.go
+++ b/authn/token_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
 )
 
 func TestAuthenticationHeaderTokenExtractorMissingHeader(t *testing.T) {

--- a/auxiliary/authorizer_charlatan.go
+++ b/auxiliary/authorizer_charlatan.go
@@ -4,8 +4,8 @@ package auxiliary
 
 import "reflect"
 import "github.com/ansel1/merry"
-import "github.com/percolate/shisa/context"
-import "github.com/percolate/shisa/httpx"
+import "github.com/shisa-platform/core/context"
+import "github.com/shisa-platform/core/httpx"
 
 // AuthorizerAuthorizeInvocation represents a single call of FakeAuthorizer.Authorize
 type AuthorizerAuthorizeInvocation struct {

--- a/auxiliary/authz.go
+++ b/auxiliary/authz.go
@@ -3,8 +3,8 @@ package auxiliary
 import (
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
 )
 
 //go:generate charlatan -output=./authorizer_charlatan.go Authorizer

--- a/auxiliary/debug.go
+++ b/auxiliary/debug.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
 )
 
 const (

--- a/auxiliary/debug_test.go
+++ b/auxiliary/debug_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/ansel1/merry"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/authn"
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/middleware"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/authn"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/middleware"
+	"github.com/shisa-platform/core/models"
 )
 
 func TestDebugServerEmpty(t *testing.T) {

--- a/auxiliary/healthcheck.go
+++ b/auxiliary/healthcheck.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/contenttype"
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/errorx"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/contenttype"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/errorx"
+	"github.com/shisa-platform/core/httpx"
 )
 
 const (

--- a/auxiliary/healthcheck_test.go
+++ b/auxiliary/healthcheck_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/ansel1/merry"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/authn"
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/middleware"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/authn"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/middleware"
+	"github.com/shisa-platform/core/models"
 )
 
 type stubHealthchecker struct {

--- a/auxiliary/http.go
+++ b/auxiliary/http.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/errorx"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/middleware"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/errorx"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/middleware"
 )
 
 const (

--- a/auxiliary/http_test.go
+++ b/auxiliary/http_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/ansel1/merry"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/authn"
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/middleware"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/authn"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/middleware"
+	"github.com/shisa-platform/core/models"
 )
 
 func unserializableResponse() httpx.Response {

--- a/auxiliary/router.go
+++ b/auxiliary/router.go
@@ -3,9 +3,9 @@ package auxiliary
 import (
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/errorx"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/errorx"
+	"github.com/shisa-platform/core/httpx"
 )
 
 type Router func(context.Context, *httpx.Request) httpx.Handler

--- a/context/context.go
+++ b/context/context.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/models"
 )
 
 type idKey struct{}

--- a/context/context_charlatan.go
+++ b/context/context_charlatan.go
@@ -6,7 +6,7 @@ import "reflect"
 import "context"
 import "time"
 import "github.com/opentracing/opentracing-go"
-import "github.com/percolate/shisa/models"
+import "github.com/shisa-platform/core/models"
 
 // ContextDeadlineInvocation represents a single call of FakeContext.Deadline
 type ContextDeadlineInvocation struct {

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/models"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/crash/crash.go
+++ b/crash/crash.go
@@ -3,8 +3,8 @@ package crash
 import (
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
 )
 
 var NoopReporter Reporter = noopReporter{}

--- a/crash/sentry.go
+++ b/crash/sentry.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/ansel1/merry"
 	"github.com/getsentry/raven-go"
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/errorx"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/errorx"
+	"github.com/shisa-platform/core/httpx"
 )
 
 var _ capturer = &raven.Client{}

--- a/crash/sentry_test.go
+++ b/crash/sentry_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/ansel1/merry"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/errorx"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/errorx"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/models"
 )
 
 func TestNewSentryReporter(t *testing.T) {

--- a/env/consul.go
+++ b/env/consul.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ansel1/merry"
 	consul "github.com/hashicorp/consul/api"
 
-	"github.com/percolate/shisa/context"
+	"github.com/shisa-platform/core/context"
 )
 
 //go:generate charlatan -output=./consulselfer_charlatan.go selfer

--- a/env/consul_test.go
+++ b/env/consul_test.go
@@ -9,7 +9,7 @@ import (
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
+	"github.com/shisa-platform/core/context"
 )
 
 var (

--- a/env/vault.go
+++ b/env/vault.go
@@ -29,7 +29,7 @@ func NewVault(c *vault.Client, prefix string) *VaultProvider {
 }
 
 func (v *VaultProvider) Get(name string) (string, merry.Error) {
-	secret, err := v.logical.Read(v.prefix)
+	secret, err := v.logical.Read(v.prefix+name)
 	if err != nil {
 		return "", merry.Prepend(err, "vault env provider: get").Append(name)
 	}

--- a/env/vault_test.go
+++ b/env/vault_test.go
@@ -57,7 +57,7 @@ func TestVaultProviderGet(t *testing.T) {
 
 	assert.Equal(t, string(defaultVal), r)
 	assert.NoError(t, err)
-	reader.AssertReadCalledOnceWith(t, defaultPrefix)
+	reader.AssertReadCalledOnceWith(t, defaultPrefix+defaultKey)
 }
 
 func TestVaultProviderGetError(t *testing.T) {
@@ -75,7 +75,7 @@ func TestVaultProviderGetError(t *testing.T) {
 
 	assert.Equal(t, "", r)
 	assert.Error(t, err)
-	reader.AssertReadCalledOnceWith(t, defaultPrefix)
+	reader.AssertReadCalledOnceWith(t, defaultPrefix+defaultKey)
 }
 
 func TestVaultProviderGetEmpty(t *testing.T) {
@@ -94,7 +94,7 @@ func TestVaultProviderGetEmpty(t *testing.T) {
 
 	assert.Equal(t, "", r)
 	assert.Error(t, err)
-	reader.AssertReadCalledOnceWith(t, defaultPrefix)
+	reader.AssertReadCalledOnceWith(t, defaultPrefix+defaultKey)
 }
 
 func TestVaultProviderGetMissing(t *testing.T) {
@@ -113,7 +113,7 @@ func TestVaultProviderGetMissing(t *testing.T) {
 
 	assert.Equal(t, "", r)
 	assert.Error(t, err)
-	reader.AssertReadCalledOnceWith(t, defaultPrefix)
+	reader.AssertReadCalledOnceWith(t, defaultPrefix+defaultKey)
 }
 
 func TestVaultProviderGetNil(t *testing.T) {
@@ -131,7 +131,7 @@ func TestVaultProviderGetNil(t *testing.T) {
 
 	assert.Equal(t, "", r)
 	assert.Error(t, err)
-	reader.AssertReadCalledOnceWith(t, defaultPrefix)
+	reader.AssertReadCalledOnceWith(t, defaultPrefix+defaultKey)
 }
 
 func TestVaultProviderGetBadString(t *testing.T) {
@@ -150,7 +150,7 @@ func TestVaultProviderGetBadString(t *testing.T) {
 
 	assert.Equal(t, "", r)
 	assert.Error(t, err)
-	reader.AssertReadCalledOnceWith(t, defaultPrefix)
+	reader.AssertReadCalledOnceWith(t, defaultPrefix+defaultKey)
 }
 
 func TestVaultProviderGetInt(t *testing.T) {
@@ -169,7 +169,7 @@ func TestVaultProviderGetInt(t *testing.T) {
 
 	assert.Equal(t, defaultInt, r)
 	assert.NoError(t, err)
-	reader.AssertReadCalledOnceWith(t, defaultPrefix)
+	reader.AssertReadCalledOnceWith(t, defaultPrefix+defaultKey)
 }
 
 func TestVaultProviderGetIntError(t *testing.T) {
@@ -187,7 +187,7 @@ func TestVaultProviderGetIntError(t *testing.T) {
 
 	assert.Equal(t, 0, r)
 	assert.Error(t, err)
-	reader.AssertReadCalledOnceWith(t, defaultPrefix)
+	reader.AssertReadCalledOnceWith(t, defaultPrefix+defaultKey)
 }
 
 func TestVaultProviderGetIntParseFailure(t *testing.T) {
@@ -206,7 +206,7 @@ func TestVaultProviderGetIntParseFailure(t *testing.T) {
 
 	assert.Equal(t, 0, r)
 	assert.Error(t, err)
-	reader.AssertReadCalledOnceWith(t, defaultPrefix)
+	reader.AssertReadCalledOnceWith(t, defaultPrefix+defaultKey)
 }
 
 func TestVaultProviderGetBool(t *testing.T) {
@@ -225,7 +225,7 @@ func TestVaultProviderGetBool(t *testing.T) {
 
 	assert.Equal(t, true, r)
 	assert.NoError(t, err)
-	reader.AssertReadCalledOnceWith(t, defaultPrefix)
+	reader.AssertReadCalledOnceWith(t, defaultPrefix+defaultKey)
 }
 
 func TestVaultProviderGetBoolError(t *testing.T) {
@@ -243,7 +243,7 @@ func TestVaultProviderGetBoolError(t *testing.T) {
 
 	assert.Equal(t, false, r)
 	assert.Error(t, err)
-	reader.AssertReadCalledOnceWith(t, defaultPrefix)
+	reader.AssertReadCalledOnceWith(t, defaultPrefix+defaultKey)
 }
 
 func TestVaultProviderGetBoolParseFailure(t *testing.T) {
@@ -262,5 +262,5 @@ func TestVaultProviderGetBoolParseFailure(t *testing.T) {
 
 	assert.Equal(t, false, r)
 	assert.Error(t, err)
-	reader.AssertReadCalledOnceWith(t, defaultPrefix)
+	reader.AssertReadCalledOnceWith(t, defaultPrefix+defaultKey)
 }

--- a/examples/gw/Dockerfile
+++ b/examples/gw/Dockerfile
@@ -2,11 +2,11 @@ FROM alpine:3.7
 
 RUN apk --no-cache --update add go musl-dev
 
-COPY ./ /root/go/src/github.com/percolate/shisa
+COPY ./ /root/go/src/github.com/shisa-platform/core
 
-WORKDIR /root/go/src/github.com/percolate/shisa/examples/gw
+WORKDIR /root/go/src/github.com/shisa-platform/core/examples/gw
 
-RUN go build -ldflags '-linkmode external -extldflags "-static" -s' -o /root/go/bin/gw github.com/percolate/shisa/examples/gw
+RUN go build -ldflags '-linkmode external -extldflags "-static" -s' -o /root/go/bin/gw github.com/shisa-platform/core/examples/gw
 
 FROM alpine:3.7
 

--- a/examples/gw/authn.go
+++ b/examples/gw/authn.go
@@ -8,10 +8,10 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/examples/idp/service"
-	"github.com/percolate/shisa/lb"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/examples/idp/service"
+	"github.com/shisa-platform/core/lb"
+	"github.com/shisa-platform/core/models"
 )
 
 type simpleUser struct {

--- a/examples/gw/authz.go
+++ b/examples/gw/authz.go
@@ -3,8 +3,8 @@ package main
 import (
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
 )
 
 type SimpleAuthorization struct {

--- a/examples/gw/headers.go
+++ b/examples/gw/headers.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/httpx"
 )
 
 func addCommonHeaders(response httpx.Response) {

--- a/examples/gw/rest.go
+++ b/examples/gw/rest.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/lb"
-	"github.com/percolate/shisa/middleware"
-	"github.com/percolate/shisa/service"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/lb"
+	"github.com/shisa-platform/core/middleware"
+	"github.com/shisa-platform/core/service"
 )
 
 type Farewell struct {

--- a/examples/gw/rpc.go
+++ b/examples/gw/rpc.go
@@ -11,11 +11,11 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/examples/rpc/service"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/lb"
-	"github.com/percolate/shisa/service"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/examples/rpc/service"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/lb"
+	"github.com/shisa-platform/core/service"
 )
 
 var (

--- a/examples/gw/serve.go
+++ b/examples/gw/serve.go
@@ -9,14 +9,14 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
-	"github.com/percolate/shisa/authn"
-	"github.com/percolate/shisa/auxiliary"
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/gateway"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/lb"
-	"github.com/percolate/shisa/middleware"
-	"github.com/percolate/shisa/sd"
+	"github.com/shisa-platform/core/authn"
+	"github.com/shisa-platform/core/auxiliary"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/gateway"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/lb"
+	"github.com/shisa-platform/core/middleware"
+	"github.com/shisa-platform/core/sd"
 )
 
 func serve(logger *zap.Logger, addr, debugAddr, healthcheckAddr string) {

--- a/examples/idp/Dockerfile
+++ b/examples/idp/Dockerfile
@@ -2,11 +2,11 @@ FROM alpine:3.7
 
 RUN apk --no-cache --update add go musl-dev
 
-COPY ./ /root/go/src/github.com/percolate/shisa
+COPY ./ /root/go/src/github.com/shisa-platform/core
 
-WORKDIR /root/go/src/github.com/percolate/shisa/examples/idp
+WORKDIR /root/go/src/github.com/shisa-platform/core/examples/idp
 
-RUN go build -ldflags '-linkmode external -extldflags "-static" -s' -o /root/go/bin/idp github.com/percolate/shisa/examples/idp
+RUN go build -ldflags '-linkmode external -extldflags "-static" -s' -o /root/go/bin/idp github.com/shisa-platform/core/examples/idp
 
 FROM alpine:3.7
 

--- a/examples/idp/serve.go
+++ b/examples/idp/serve.go
@@ -14,9 +14,9 @@ import (
 	consul "github.com/hashicorp/consul/api"
 	"go.uber.org/zap"
 
-	"github.com/percolate/shisa/examples/idp/service"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/sd"
+	"github.com/shisa-platform/core/examples/idp/service"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/sd"
 )
 
 func serve(logger *zap.Logger, addr string) {

--- a/examples/rest/Dockerfile
+++ b/examples/rest/Dockerfile
@@ -2,11 +2,11 @@ FROM alpine:3.7
 
 RUN apk --no-cache --update add go musl-dev
 
-COPY ./ /root/go/src/github.com/percolate/shisa
+COPY ./ /root/go/src/github.com/shisa-platform/core
 
-WORKDIR /root/go/src/github.com/percolate/shisa/examples/rest
+WORKDIR /root/go/src/github.com/shisa-platform/core/examples/rest
 
-RUN go build -ldflags '-linkmode external -extldflags "-static" -s' -o /root/go/bin/rest github.com/percolate/shisa/examples/rest
+RUN go build -ldflags '-linkmode external -extldflags "-static" -s' -o /root/go/bin/rest github.com/shisa-platform/core/examples/rest
 
 FROM alpine:3.7
 

--- a/examples/rest/goodbye.go
+++ b/examples/rest/goodbye.go
@@ -16,10 +16,10 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/examples/idp/service"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/lb"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/examples/idp/service"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/lb"
 )
 
 const idpServiceName = "idp"

--- a/examples/rest/serve.go
+++ b/examples/rest/serve.go
@@ -13,9 +13,9 @@ import (
 	consul "github.com/hashicorp/consul/api"
 	"go.uber.org/zap"
 
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/lb"
-	"github.com/percolate/shisa/sd"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/lb"
+	"github.com/shisa-platform/core/sd"
 )
 
 func serve(logger *zap.Logger, addr string) {

--- a/examples/rpc/Dockerfile
+++ b/examples/rpc/Dockerfile
@@ -2,11 +2,11 @@ FROM alpine:3.7
 
 RUN apk --no-cache --update add go musl-dev
 
-COPY ./ /root/go/src/github.com/percolate/shisa
+COPY ./ /root/go/src/github.com/shisa-platform/core
 
-WORKDIR /root/go/src/github.com/percolate/shisa/examples/rpc
+WORKDIR /root/go/src/github.com/shisa-platform/core/examples/rpc
 
-RUN go build -ldflags '-linkmode external -extldflags "-static" -s' -o /root/go/bin/rpc github.com/percolate/shisa/examples/rpc
+RUN go build -ldflags '-linkmode external -extldflags "-static" -s' -o /root/go/bin/rpc github.com/shisa-platform/core/examples/rpc
 
 FROM alpine:3.7
 

--- a/examples/rpc/serve.go
+++ b/examples/rpc/serve.go
@@ -14,10 +14,10 @@ import (
 	consul "github.com/hashicorp/consul/api"
 	"go.uber.org/zap"
 
-	"github.com/percolate/shisa/examples/rpc/service"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/lb"
-	"github.com/percolate/shisa/sd"
+	"github.com/shisa-platform/core/examples/rpc/service"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/lb"
+	"github.com/shisa-platform/core/sd"
 )
 
 func serve(logger *zap.Logger, addr string) {

--- a/examples/rpc/service/hello.go
+++ b/examples/rpc/service/hello.go
@@ -10,8 +10,8 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"go.uber.org/zap"
 
-	"github.com/percolate/shisa/examples/idp/service"
-	"github.com/percolate/shisa/lb"
+	"github.com/shisa-platform/core/examples/idp/service"
+	"github.com/shisa-platform/core/lb"
 )
 
 const idpServiceName = "idp"

--- a/gateway/endpoint.go
+++ b/gateway/endpoint.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/service"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/service"
 )
 
 type endpoint struct {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -15,10 +15,10 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/auxiliary"
-	"github.com/percolate/shisa/errorx"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/sd"
+	"github.com/shisa-platform/core/auxiliary"
+	"github.com/shisa-platform/core/errorx"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/sd"
 )
 
 const (

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/ansel1/merry"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/sd"
-	"github.com/percolate/shisa/service"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/sd"
+	"github.com/shisa-platform/core/service"
 )
 
 func waitSig(t *testing.T, c <-chan os.Signal, sig os.Signal) {

--- a/gateway/package_test.go
+++ b/gateway/package_test.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/service"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/service"
 )
 
 var (

--- a/gateway/router.go
+++ b/gateway/router.go
@@ -11,10 +11,10 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/errorx"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/service"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/errorx"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/service"
 )
 
 var (

--- a/gateway/router_test.go
+++ b/gateway/router_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/ansel1/merry"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/authn"
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/middleware"
-	"github.com/percolate/shisa/models"
-	"github.com/percolate/shisa/service"
+	"github.com/shisa-platform/core/authn"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/middleware"
+	"github.com/shisa-platform/core/models"
+	"github.com/shisa-platform/core/service"
 )
 
 func failingResponse(status int) httpx.Response {

--- a/gateway/serve.go
+++ b/gateway/serve.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/errorx"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/service"
+	"github.com/shisa-platform/core/errorx"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/service"
 )
 
 type byName []httpx.ParameterSchema

--- a/gateway/serve_test.go
+++ b/gateway/serve_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/ansel1/merry"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/sd"
-	"github.com/percolate/shisa/service"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/sd"
+	"github.com/shisa-platform/core/service"
 )
 
 func TestGatewayNoServices(t *testing.T) {

--- a/gateway/tree.go
+++ b/gateway/tree.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/httpx"
 )
 
 func min(a, b int) int {

--- a/gateway/tree_test.go
+++ b/gateway/tree_test.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/service"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/service"
 )
 
 func printChildren(n *node, prefix string) {

--- a/httpx/handler.go
+++ b/httpx/handler.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/errorx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/errorx"
 )
 
 // Handler is a block of logic to apply to a request.

--- a/httpx/handler_test.go
+++ b/httpx/handler_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ansel1/merry"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
+	"github.com/shisa-platform/core/context"
 )
 
 func TestHandlerPanic(t *testing.T) {

--- a/httpx/helper.go
+++ b/httpx/helper.go
@@ -3,8 +3,8 @@ package httpx
 import (
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/errorx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/errorx"
 )
 
 // StringExtractor is a function type that extracts a string from

--- a/httpx/helper_test.go
+++ b/httpx/helper_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ansel1/merry"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
+	"github.com/shisa-platform/core/context"
 )
 
 func TestStringExtractorPanic(t *testing.T) {

--- a/httpx/hook.go
+++ b/httpx/hook.go
@@ -3,8 +3,8 @@ package httpx
 import (
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/errorx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/errorx"
 )
 
 type ErrorHook func(context.Context, *Request, merry.Error)

--- a/httpx/hook_test.go
+++ b/httpx/hook_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ansel1/merry"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
+	"github.com/shisa-platform/core/context"
 )
 
 func TestErrorHookNil(t *testing.T) {

--- a/httpx/request.go
+++ b/httpx/request.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/uuid"
+	"github.com/shisa-platform/core/uuid"
 )
 
 var (

--- a/httpx/response.go
+++ b/httpx/response.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/contenttype"
+	"github.com/shisa-platform/core/contenttype"
 )
 
 const (

--- a/httpx/validator.go
+++ b/httpx/validator.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ansel1/merry"
 	"go.uber.org/multierr"
 
-	"github.com/percolate/shisa/errorx"
+	"github.com/shisa-platform/core/errorx"
 )
 
 var (

--- a/httpx/writer.go
+++ b/httpx/writer.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/errorx"
+	"github.com/shisa-platform/core/errorx"
 )
 
 // WriteResponse serializes a response instance to the

--- a/lb/cache.go
+++ b/lb/cache.go
@@ -3,7 +3,7 @@ package lb
 import (
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/sd"
+	"github.com/shisa-platform/core/sd"
 )
 
 // Cache encapsulates the stateful parts of a load balancer

--- a/lb/cache_test.go
+++ b/lb/cache_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/sd"
+	"github.com/shisa-platform/core/sd"
 )
 
 func TestRRCache(t *testing.T) {

--- a/lb/leastn.go
+++ b/lb/leastn.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/percolate/shisa/sd"
+	"github.com/shisa-platform/core/sd"
 )
 
 var _ Cache = &leastConnsCache{}

--- a/lb/leastn_test.go
+++ b/lb/leastn_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ansel1/merry"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/sd"
+	"github.com/shisa-platform/core/sd"
 )
 
 func TestLeastNBalance(t *testing.T) {

--- a/lb/random.go
+++ b/lb/random.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/ansel1/merry"
 
-	"github.com/percolate/shisa/sd"
+	"github.com/shisa-platform/core/sd"
 )
 
 var _ Balancer = &randomLB{}

--- a/lb/random_test.go
+++ b/lb/random_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/ansel1/merry"
-	"github.com/percolate/shisa/sd"
+	"github.com/shisa-platform/core/sd"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/lb/roundrobin.go
+++ b/lb/roundrobin.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/percolate/shisa/sd"
+	"github.com/shisa-platform/core/sd"
 )
 
 var _ Cache = &rrCache{}

--- a/lb/roundrobin_test.go
+++ b/lb/roundrobin_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/ansel1/merry"
-	"github.com/percolate/shisa/sd"
+	"github.com/shisa-platform/core/sd"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/middleware/authentication.go
+++ b/middleware/authentication.go
@@ -8,11 +8,11 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 
-	"github.com/percolate/shisa/authn"
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/errorx"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/authn"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/errorx"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/models"
 )
 
 const (

--- a/middleware/authentication_test.go
+++ b/middleware/authentication_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/authn"
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/models"
+	"github.com/shisa-platform/core/authn"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/models"
 )
 
 var (

--- a/middleware/contenttype.go
+++ b/middleware/contenttype.go
@@ -9,9 +9,9 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 
-	"github.com/percolate/shisa/contenttype"
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/contenttype"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
 )
 
 const (

--- a/middleware/contenttype_test.go
+++ b/middleware/contenttype_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/contenttype"
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/contenttype"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
 )
 
 type contentTypeTest struct {

--- a/middleware/csrf.go
+++ b/middleware/csrf.go
@@ -11,9 +11,9 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/errorx"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/errorx"
+	"github.com/shisa-platform/core/httpx"
 )
 
 const (

--- a/middleware/csrf_test.go
+++ b/middleware/csrf_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
 )
 
 const (

--- a/middleware/proxy.go
+++ b/middleware/proxy.go
@@ -10,9 +10,9 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/errorx"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/errorx"
+	"github.com/shisa-platform/core/httpx"
 )
 
 var (

--- a/middleware/proxy_test.go
+++ b/middleware/proxy_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
 )
 
 func TestReverseProxyMissingRouter(t *testing.T) {

--- a/middleware/ratelimit.go
+++ b/middleware/ratelimit.go
@@ -10,10 +10,10 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/errorx"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/ratelimit"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/errorx"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/ratelimit"
 )
 
 const (

--- a/middleware/ratellimit_test.go
+++ b/middleware/ratellimit_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
-	"github.com/percolate/shisa/models"
-	"github.com/percolate/shisa/ratelimit"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
+	"github.com/shisa-platform/core/models"
+	"github.com/shisa-platform/core/ratelimit"
 )
 
 func lolExtractor(context.Context, *httpx.Request) (string, merry.Error) {

--- a/ratelimit/provider.go
+++ b/ratelimit/provider.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ansel1/merry"
 	"time"
 
-	"github.com/percolate/shisa/context"
+	"github.com/shisa-platform/core/context"
 )
 
 //go:generate charlatan -output=./provider_charlatan.go Provider

--- a/ratelimit/provider_charlatan.go
+++ b/ratelimit/provider_charlatan.go
@@ -5,7 +5,7 @@ package ratelimit
 import "reflect"
 import "github.com/ansel1/merry"
 import "time"
-import "github.com/percolate/shisa/context"
+import "github.com/shisa-platform/core/context"
 
 // ProviderLimitInvocation represents a single call of FakeProvider.Limit
 type ProviderLimitInvocation struct {

--- a/service/endpoint.go
+++ b/service/endpoint.go
@@ -3,7 +3,7 @@ package service
 import (
 	"bytes"
 
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/httpx"
 )
 
 // Endpoint is collection of pipelines for a route (URL path),

--- a/service/endpoint_test.go
+++ b/service/endpoint_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/percolate/shisa/context"
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/context"
+	"github.com/shisa-platform/core/httpx"
 )
 
 var (

--- a/service/pipeline.go
+++ b/service/pipeline.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/httpx"
 )
 
 // Pipeline is a chain of handlers to be invoked in order on a

--- a/service/service.go
+++ b/service/service.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"github.com/percolate/shisa/httpx"
+	"github.com/shisa-platform/core/httpx"
 )
 
 // Service is a logical grouping of related endpoints.

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -11,7 +11,7 @@ var (
 	NamespaceDNS = mustParse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	NamespaceURL = mustParse("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
 
-	// URL Namespace and "https://github.com/percolate/shisa"
+	// URL Namespace and "https://github.com/shisa-platform/core"
 	ShisaNS = mustParse("e06bac7c-4f4b-5c54-a632-d48a16695027")
 )
 


### PR DESCRIPTION
When querying vault today we read from the `<prefix>/` and search within the returned data for the specific key. See: https://github.com/shisa-platform/core/blob/master/env/vault.go#L32 

This PR will update the Vault functionality such that we will read from `<prefix>/<key>` instead.

Also, all of the old paths referencing shisa in its old location have been updated to reflect the new repo. 


